### PR TITLE
Add a query string parameter to chose the screenshot output format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ node_modules
 photobooth.txt
 
 .idea
+*.sublime-project
+*.sublime-workspace
+

--- a/routes/api.js
+++ b/routes/api.js
@@ -5,6 +5,13 @@ var urlUtil = require('url');
 var imageService = require('../service/imageService');
 //Routes
 
+
+const CONTENT_TYPES = {
+    jpeg: 'image/jpeg',
+    png: 'image/png',
+    gif: 'image/gif'
+};
+
 // Function catches all requests to /screenshot/* and makes sure url passed in is encoded
 // 1) /screenshoot/http://www.google.com ==> /screenshot/http%3A%2F%2Fwww.google.com
 // 2) /screenshoot/http%3A%2F%2Fwww.google.com ==> /screenshot/http%3A%2F%2Fwww.google.com
@@ -21,16 +28,24 @@ router.get('/screenshot/*', function (req, res, next) {
 // Route where we take a screenshot. It expects :url to be encoded
 // Otherwise this route will be missed
 router.get('/screenshot/:url', function (req, res) {
+
     //first get url that is passed in as param
     var url = decodeURIComponent(req.params.url);
     //get url params - of current url
     var url_parts = urlUtil.parse(req.url, true);
     var query = url_parts.query;
 
+    var contentType = (function (format) {
+        if (!format || !CONTENT_TYPES[format.toLowerCase()]) {
+            return CONTENT_TYPES['jpeg'];
+        }
+        return CONTENT_TYPES[format.toLowerCase()];
+    } (query.format));
+
     imageService.fetchScreenshot(url, query).then(function (data) {
         var img = new Buffer(data, 'base64');
         res.writeHead(200, {
-            'Content-Type': 'image/png',
+            'Content-Type': contentType,
             'Content-Length': img.length
         });
         res.end(img);

--- a/service/phantomJs.js
+++ b/service/phantomJs.js
@@ -4,15 +4,28 @@ var CONFIG = require('../config/config');
 
 var ALLOWED_ORIGINS = CONFIG.allowed_origins;
 
+// as supported by PhantomJS http://phantomjs.org/api/webpage/method/render-base64.html
+const OUTPUT_FORMATS = {
+    jpeg: 'JPEG',
+    png: 'PNG',
+    gif: 'GIF'
+};
+
 var phantomJS = {};
 
 phantomJS.screenshot = function (url, query) {
 
     return new Promise(function (resolveScreenshot, rejectScreenshot) {
 
+        var page;
         var viewportWidth = parseInt(query.w) || 800;
         var viewportHeight = parseInt(query.h) || 600;
-        var page;
+        var outputFormat = (function (format) {
+            if (!format || !OUTPUT_FORMATS[format.toLowerCase()]) {
+                return OUTPUT_FORMATS['jpeg'];
+            }
+            return OUTPUT_FORMATS[format.toLowerCase()];
+        } (query.format));
 
         if (!isValidOrigin(url)) {
             var response = {
@@ -60,7 +73,7 @@ phantomJS.screenshot = function (url, query) {
                             return document.readyState;
                         }).then(function (result) {
                             if ("complete" === result) {
-                                page.renderBase64('png').then(function (data) {
+                                page.renderBase64(outputFormat).then(function (data) {
                                     page.close();
                                     ph.exit();
                                     resolveScreenshot(data);


### PR DESCRIPTION
Change the default format for screenshots to 'JPEG' for a smaller image.

Compare http://localhost:3000/api/screenshot/https%3A%2F%2Fperegrine-api.onefootball.com%2Fphotobooth%2Fcms%2Ffr%2F12088175%3F?format=png and http://localhost:3000/api/screenshot/https%3A%2F%2Fperegrine-api.onefootball.com%2Fphotobooth%2Fcms%2Ffr%2F12088175%3F
